### PR TITLE
feat: use JavaDependency component for bom

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,19 @@
+name: Test
+on: [push, pull_request]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Setup Node
+        uses: actions/setup-node@v3
+        with:
+          node-version: lts/*
+      - name: Build Docs
+        run: |
+          cd docs
+          yarn install
+          yarn build

--- a/docs/package.json
+++ b/docs/package.json
@@ -21,7 +21,7 @@
     "@mdx-js/react": "1.6.22",
     "@mui/icons-material": "5.8.4",
     "@mui/material": "5.10.0",
-    "@philippheuer/docusaurus-components": "0.2.0",
+    "@philippheuer/docusaurus-components": "0.2.1",
     "clsx": "1.2.1",
     "prism-react-renderer": "1.3.5",
     "react": "17.0.2",

--- a/docs/versioned_docs/version-0.x/getting-started/installation.mdx
+++ b/docs/versioned_docs/version-0.x/getting-started/installation.mdx
@@ -4,6 +4,7 @@ sidebar_position: 1
 
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
+import { JavaDependency } from '@philippheuer/docusaurus-components';
 
 # Installation
 
@@ -15,95 +16,24 @@ The `cache-bom` will ensure that all xanthic-components in your project use the 
 
 You will want to include the `xanthic-core` to code against this straightforward API and let users can choose whichever backing implementation they prefer!
 
-<Tabs groupId="dependency">
-<TabItem value="gradle-groovy" label="Gradle - Groovy">
+### Step 1: add the bom to your project:
 
-```groovy
-api platform("io.github.xanthic.cache:cache-bom:0.1.0")
-api "io.github.xanthic.cache:cache-core"
-```
+<JavaDependency group="io.github.xanthic.cache" name="cache-bom" version="0.1.0" bom="true" scope="api" />
 
-</TabItem>
-<TabItem value="gradle-kotlin" label="Gradle - Kotlin DSL">
+### Step 2: add the `cache-core` dependency:
 
-```kotlin
-api(platform("io.github.xanthic.cache:cache-bom:0.1.0"))
-api("io.github.xanthic.cache:cache-core")
-```
-
-</TabItem>
-<TabItem value="maven" label="Maven">
-
-```xml
-<dependencyManagement>
-    <dependencies>
-        <dependency>
-            <groupId>io.github.xanthic.cache</groupId>
-            <artifactId>cache-bom</artifactId>
-            <version>0.1.0</version>
-            <type>pom</type>
-            <scope>import</scope>
-        </dependency>
-    </dependencies>
-</dependencyManagement>
-
-<dependencies>
-    <dependency>
-        <groupId>io.github.xanthic.cache</groupId>
-        <artifactId>cache-core</artifactId>
-    </dependency>
-</dependencies>
-```
-
-</TabItem>
-</Tabs>
+<JavaDependency group="io.github.xanthic.cache" name="cache-core" scope="api" />
 
 ## Usage: For Application Developers
 
 As user of a library that is using xanthic, you will only need to specify the `bom` and pick your one or more implementations of your choice.
-See all supported implementations [here](/provider).
 
-This example shows how to include caffeine3:
+### Step 1: add the bom to your project:
 
-<Tabs groupId="dependency">
-<TabItem value="gradle-groovy" label="Gradle - Groovy">
+<JavaDependency group="io.github.xanthic.cache" name="cache-bom" version="0.1.0" bom="true" scope="implementation" />
 
-```groovy
-implementation platform("io.github.xanthic.cache:cache-bom:0.1.0")
-implementation "io.github.xanthic.cache:cache-provider-caffeine3"
-```
+### Step 2: add a cache-implementation of your choice:
 
-</TabItem>
-<TabItem value="gradle-kotlin" label="Gradle - Kotlin DSL">
+See all supported implementations [here](/provider)
 
-```kotlin
-implementation(platform("io.github.xanthic.cache:cache-bom:0.1.0"))
-implementation("io.github.xanthic.cache:cache-provider-caffeine3")
-```
-
-</TabItem>
-<TabItem value="maven" label="Maven">
-
-```xml
-<dependencyManagement>
-    <dependencies>
-        <dependency>
-            <groupId>io.github.xanthic.cache</groupId>
-            <artifactId>cache-bom</artifactId>
-            <version>0.1.0</version>
-            <type>pom</type>
-            <scope>import</scope>
-        </dependency>
-    </dependencies>
-</dependencyManagement>
-
-<dependencies>
-    <dependency>
-        <groupId>io.github.xanthic.cache</groupId>
-        <artifactId>cache-provider-caffeine3</artifactId>
-    </dependency>
-</dependencies>
-```
-
-</TabItem>
-</Tabs>
+<JavaDependency group="io.github.xanthic.cache" name="cache-provider-caffeine3" scope="implementation" />

--- a/docs/yarn.lock
+++ b/docs/yarn.lock
@@ -1903,10 +1903,10 @@
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
 
-"@philippheuer/docusaurus-components@0.2.0":
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/@philippheuer/docusaurus-components/-/docusaurus-components-0.2.0.tgz#4940e7901c1bb8dc1cfb059f842aa6c3392603b4"
-  integrity sha512-fX5Be4x4qU/aGLM0/rhiu7RBeRngV/aU2TPbzKRLTvkY9Xko+bpxnH95qu/kHyWTUzm5Ai/9yQQLa80NXCnE9Q==
+"@philippheuer/docusaurus-components@0.2.1":
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/@philippheuer/docusaurus-components/-/docusaurus-components-0.2.1.tgz#e8195d480787e1b88d281b36ffc016ee9c3ee8b3"
+  integrity sha512-h3qHAFlYXbXfnEhl4ik7WaH9cxia1FU8Qj06Y1rz5+/YEcbuZXaSP7/iLZHyils60WwfFeH7QQuVFZ9BUMswiQ==
   dependencies:
     "@docusaurus/theme-classic" "2.0.1"
 

--- a/renovate.json
+++ b/renovate.json
@@ -8,8 +8,7 @@
       ":prConcurrentLimitNone",
       ":disableDependencyDashboard",
       ":separateMultipleMajorReleases",
-      ":combinePatchMinorReleases",
-      ":pinVersions"
+      ":combinePatchMinorReleases"
   ],
   "assignees": [],
   "branchPrefix": "chore/dependencies/",


### PR DESCRIPTION
## Changes

- use the `JavaDependency` component for the bom
- add a gh action test workflow
- disable pinVersions renovate preset (because of engine node pin PR)