### PR TITLE
docs: explain the example usage in words

### DIFF
--- a/docs/versioned_docs/version-0.x/intro.mdx
+++ b/docs/versioned_docs/version-0.x/intro.mdx
@@ -20,6 +20,8 @@ Application developers can utilize Xanthic to easily switch between different [b
 
 ## Example Usage
 
+Create a cache (with `String` keys and `Integer` values) that can hold up to 2048 elements, where entries expire 5 minutes following their latest access, and removed entries notify a specific event listener:
+
 ```java
 Cache<String, Integer> cache = CacheApi.create(spec -> {
     spec.maxSize(2048L);

--- a/docs/versioned_docs/version-0.x/intro.mdx
+++ b/docs/versioned_docs/version-0.x/intro.mdx
@@ -5,6 +5,8 @@ slug: /
 ---
 
 import useBaseUrl from '@docusaurus/useBaseUrl';
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
 import Alert from "@mui/material/Alert";
 
 # 
@@ -13,16 +15,20 @@ import Alert from "@mui/material/Alert";
 
 Xanthic is a straightforward API for in-memory caching on the JVM, via the facade pattern.
 
-Library developers can utilize Xanthic to [enable](/getting-started/installation#usage-for-library-developers) caching without marrying a single implementation.
+- Library developers can utilize Xanthic to [enable](/getting-started/installation#usage-for-library-developers) caching without marrying a single implementation
+- Application developers can utilize Xanthic to easily switch between different [backing implementations](/provider/) whenever desired
 
-Application developers can utilize Xanthic to easily switch between different [backing implementations](/provider/) whenever desired.
+## Usage Example
 
-## Example Usage
+### Create Cache
 
 Create a [cache](https://javadoc.io/doc/io.github.xanthic.cache/cache-api/latest/io/github/xanthic/cache/api/Cache.html) (with `String` keys and `Integer` values)
 that can hold [up to](https://javadoc.io/doc/io.github.xanthic.cache/cache-api/latest/io/github/xanthic/cache/api/ICacheSpec.html#maxSize()) 2048 elements,
 where entries [expire](https://javadoc.io/doc/io.github.xanthic.cache/cache-api/latest/io/github/xanthic/cache/api/ICacheSpec.html#expiryType()) 5 minutes following their latest access,
 and removed entries notify a specific event [listener](https://javadoc.io/doc/io.github.xanthic.cache/cache-api/latest/io/github/xanthic/cache/api/ICacheSpec.html#removalListener()):
+
+<Tabs>
+  <TabItem value="java" label="Java" default>
 
 ```java
 Cache<String, Integer> cache = CacheApi.create(spec -> {
@@ -37,17 +43,34 @@ Cache<String, Integer> cache = CacheApi.create(spec -> {
 });
 ```
 
-<br/>
+  </TabItem>
+  <TabItem value="kotlin" label="Kotlin">
 
-Since `CacheApiSpec#provider(CacheProvider)` was not specified, the default cache provider will be used:
-
-* Application developers should add at least one `cache-provider-x` [module](/provider/) to their project <sup>(or create their own)</sup>
-* When there is only one cache provider registered, it will automatically become the [default](https://javadoc.io/doc/io.github.xanthic.cache/cache-core/latest/io/github/xanthic/cache/core/CacheApiSettings.html#getDefaultCacheProvider()) provider
-* When there are multiple cache provider modules installed, the default will be selected according to the [discovery order](/provider/) <sup>(but it is not recommended to rely on this order)</sup>
-* Users can explicitly define which cache provider should be used as the default by calling [CacheApiSettings](https://javadoc.io/doc/io.github.xanthic.cache/cache-core/latest/io/github/xanthic/cache/core/CacheApiSettings.html#setDefaultCacheProvider(io.github.xanthic.cache.api.CacheProvider)). This will override whatever default was chosen from the discovery order
-
-<br/>
+```kotlin
+val cache = createCache<String, Int> {
+    maxSize = 2048
+    expiryType = ExpiryType.POST_ACCESS // or ExpiryType.POST_WRITE
+    expiryTime = Duration.ofMinutes(5)
+    removalListener { key, value, cause ->
+        if (cause.isEviction) {
+            // do something
+        }
+    }
+}
+```
 
 <Alert severity="info" variant="outlined">
     <b>Kotlin</b> users can enjoy <a href="/getting-started/kotlin#createcache">more idiomatic syntax</a> via the extensions module!
 </Alert>
+
+  </TabItem>
+</Tabs>
+
+Since `CacheApiSpec#provider(CacheProvider)` was not specified, the <b>default cache provider</b> will be used.
+
+### Default Cache Provider
+
+* Application developers should add at least one `cache-provider-x` [module](/provider/) to their project <sup>(or create their own)</sup>
+* When there is only one cache provider registered, it will automatically become the [default cache provider](https://javadoc.io/doc/io.github.xanthic.cache/cache-core/latest/io/github/xanthic/cache/core/CacheApiSettings.html#getDefaultCacheProvider())
+* When there are multiple cache provider modules installed, the default will be selected according to the [discovery order](/provider/) <br /><sup>(but it is not recommended to rely on this order)</sup>
+* Users can explicitly define which cache provider should be used as the default by calling [CacheApiSettings](https://javadoc.io/doc/io.github.xanthic.cache/cache-core/latest/io/github/xanthic/cache/core/CacheApiSettings.html#setDefaultCacheProvider(io.github.xanthic.cache.api.CacheProvider)). This will override whatever default was chosen from the discovery order

--- a/docs/versioned_docs/version-0.x/intro.mdx
+++ b/docs/versioned_docs/version-0.x/intro.mdx
@@ -49,8 +49,8 @@ Cache<String, Integer> cache = CacheApi.create(spec -> {
 ```kotlin
 val cache = createCache<String, Int> {
     maxSize = 2048
-    expiryType = ExpiryType.POST_ACCESS // or ExpiryType.POST_WRITE
     expiryTime = Duration.ofMinutes(5)
+    expiryType = ExpiryType.POST_ACCESS // or ExpiryType.POST_WRITE
     removalListener { key, value, cause ->
         if (cause.isEviction) {
             // do something
@@ -60,7 +60,7 @@ val cache = createCache<String, Int> {
 ```
 
 <Alert severity="info" variant="outlined">
-    <b>Kotlin</b> users can enjoy <a href="/getting-started/kotlin#createcache">more idiomatic syntax</a> via the extensions module!
+    <b>Kotlin</b> users can enjoy this more idiomatic syntax via the <a href="/getting-started/kotlin">extensions module</a>.
 </Alert>
 
   </TabItem>
@@ -70,7 +70,7 @@ Since `CacheApiSpec#provider(CacheProvider)` was not specified, the <b>default c
 
 ### Default Cache Provider
 
-* Application developers should add at least one `cache-provider-x` [module](/provider/) to their project <sup>(or create their own)</sup>
+* Application developers [should](/getting-started/installation#usage-for-application-developers) add at least one `cache-provider-𝑥` module to their project <sup>(or create their own)</sup>
 * When there is only one cache provider registered, it will automatically become the [default cache provider](https://javadoc.io/doc/io.github.xanthic.cache/cache-core/latest/io/github/xanthic/cache/core/CacheApiSettings.html#getDefaultCacheProvider())
-* When there are multiple cache provider modules installed, the default will be selected according to the [discovery order](/provider/) <br /><sup>(but it is not recommended to rely on this order)</sup>
+* When there are multiple cache provider modules installed, the default will be selected according to the [discovery order](/provider/) <sup>(but it is not recommended to rely on this order)</sup>
 * Users can explicitly define which cache provider should be used as the default by calling [CacheApiSettings](https://javadoc.io/doc/io.github.xanthic.cache/cache-core/latest/io/github/xanthic/cache/core/CacheApiSettings.html#setDefaultCacheProvider(io.github.xanthic.cache.api.CacheProvider)). This will override whatever default was chosen from the discovery order

--- a/docs/versioned_docs/version-0.x/intro.mdx
+++ b/docs/versioned_docs/version-0.x/intro.mdx
@@ -4,9 +4,8 @@ sidebar_label: Home
 slug: /
 ---
 
-import Tabs from '@theme/Tabs';
-import TabItem from '@theme/TabItem';
 import useBaseUrl from '@docusaurus/useBaseUrl';
+import Alert from "@mui/material/Alert";
 
 # 
 
@@ -20,13 +19,16 @@ Application developers can utilize Xanthic to easily switch between different [b
 
 ## Example Usage
 
-Create a cache (with `String` keys and `Integer` values) that can hold up to 2048 elements, where entries expire 5 minutes following their latest access, and removed entries notify a specific event listener:
+Create a [cache](https://javadoc.io/doc/io.github.xanthic.cache/cache-api/latest/io/github/xanthic/cache/api/Cache.html) (with `String` keys and `Integer` values)
+that can hold [up to](https://javadoc.io/doc/io.github.xanthic.cache/cache-api/latest/io/github/xanthic/cache/api/ICacheSpec.html#maxSize()) 2048 elements,
+where entries [expire](https://javadoc.io/doc/io.github.xanthic.cache/cache-api/latest/io/github/xanthic/cache/api/ICacheSpec.html#expiryType()) 5 minutes following their latest access,
+and removed entries notify a specific event [listener](https://javadoc.io/doc/io.github.xanthic.cache/cache-api/latest/io/github/xanthic/cache/api/ICacheSpec.html#removalListener()):
 
 ```java
 Cache<String, Integer> cache = CacheApi.create(spec -> {
     spec.maxSize(2048L);
     spec.expiryTime(Duration.ofMinutes(5L));
-    spec.expiryType(ExpiryType.POST_ACCESS);
+    spec.expiryType(ExpiryType.POST_ACCESS); // or ExpiryType.POST_WRITE
     spec.removalListener((key, value, cause) -> {
         if (cause.isEviction()) {
             // do something
@@ -35,4 +37,17 @@ Cache<String, Integer> cache = CacheApi.create(spec -> {
 });
 ```
 
-The methods defined on the `Cache` object can be found in the [Javadoc](https://javadoc.io/doc/io.github.xanthic.cache/cache-api/latest/io/github/xanthic/cache/api/Cache.html).
+<br/>
+
+Since `CacheApiSpec#provider(CacheProvider)` was not specified, the default cache provider will be used:
+
+* Application developers should add at least one `cache-provider-x` [module](/provider/) to their project <sup>(or create their own)</sup>
+* When there is only one cache provider registered, it will automatically become the [default](https://javadoc.io/doc/io.github.xanthic.cache/cache-core/latest/io/github/xanthic/cache/core/CacheApiSettings.html#getDefaultCacheProvider()) provider
+* When there are multiple cache provider modules installed, the default will be selected according to the [discovery order](/provider/) <sup>(but it is not recommended to rely on this order)</sup>
+* Users can explicitly define which cache provider should be used as the default by calling [CacheApiSettings](https://javadoc.io/doc/io.github.xanthic.cache/cache-core/latest/io/github/xanthic/cache/core/CacheApiSettings.html#setDefaultCacheProvider(io.github.xanthic.cache.api.CacheProvider)). This will override whatever default was chosen from the discovery order
+
+<br/>
+
+<Alert severity="info" variant="outlined">
+    <b>Kotlin</b> users can enjoy <a href="/getting-started/kotlin#createcache">more idiomatic syntax</a> via the extensions module!
+</Alert>


### PR DESCRIPTION
Provides some clarity to users with less familiarity with cache libraries