### PR TITLE
fix: redirect to correct provider index

### DIFF
--- a/docs/versioned_docs/version-0.x/getting-started/installation.mdx
+++ b/docs/versioned_docs/version-0.x/getting-started/installation.mdx
@@ -34,6 +34,6 @@ As user of a library that is using xanthic, you will only need to specify the `b
 
 ### Step 2: add a cache-implementation of your choice:
 
-See all supported implementations [here](/provider)
+See all supported implementations [here](/provider/)
 
 <JavaDependency group="io.github.xanthic.cache" name="cache-provider-caffeine3" scope="implementation" />


### PR DESCRIPTION
The missing trailing slash resulted in the individual provider links from the index being broken 